### PR TITLE
feat: configured aliasing paths in project

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -2,7 +2,7 @@
 
 import { AxiosError } from "axios";
 import axiosClient from "./axios";
-import { ILoginForm, IRegisterForm } from "../models";
+import { ILoginForm, IRegisterForm } from "@/models";
 import { toast } from "react-hot-toast";
 
 type IResponse<T = unknown> = {
@@ -76,4 +76,23 @@ export const signinUser = async (
         }
 	}
     return null;
+};
+
+
+
+
+export const verifyEmail = async (body: {
+	email: string;
+}): Promise<IResponse | null> => {
+	try {
+		const { data } = await axiosClient.post<IResponse>("/auth/password/reset/", body);
+        toast.success(data.message);
+		return data;
+	} catch (err) {
+		if (err instanceof AxiosError){
+            const { data: { errors } } = err.response!
+            toast.error(errors[0]);
+        }
+		return null;
+	}
 };

--- a/src/components/AvatarUsers.tsx
+++ b/src/components/AvatarUsers.tsx
@@ -1,4 +1,4 @@
-import { Avatars } from '../assets';
+import { Avatars } from '@/assets';
 
 const AvatarUsers = (
   // { amount }: { amount?: number }

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -1,7 +1,7 @@
 
 import { Swiper, SwiperSlide } from 'swiper/react';
 import {  Pagination, Autoplay, EffectCoverflow } from 'swiper/modules';
-import {AuthImages} from '../../assets'
+import {AuthImages} from '@/assets'
 
 
 import 'swiper/css';

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,7 +1,7 @@
 import { Badge, Button } from './layout';
 import { Link } from 'react-router-dom';
 import { GoArrowUpRight } from 'react-icons/go';
-import { cn } from '../utils/constants';
+import { cn } from '@/utils/constants';
 
 interface EventCardProps {
   discoverMore?: boolean;

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,4 +1,4 @@
-import { HomeImages } from "../assets";
+import { HomeImages } from "@/assets";
 import { Badge } from "./layout";
 import { GrArticle } from "react-icons/gr";
 import { GoArrowUpRight } from "react-icons/go";

--- a/src/components/layout/badge/Badge.tsx
+++ b/src/components/layout/badge/Badge.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { cn } from '../../../utils/constants';
+import { cn } from '@/utils/constants';
 
 
 interface BadgeProps {

--- a/src/components/layout/base-layout/BaseLayout.tsx
+++ b/src/components/layout/base-layout/BaseLayout.tsx
@@ -1,5 +1,5 @@
-import Navbar from '../navbar/Navbar';
-import Footer from '../footer/Footer';
+import Navbar from '@/components/layout/navbar/Navbar';
+import Footer from '@/components/layout/footer/Footer';
 import { Outlet } from 'react-router-dom';
 
 

--- a/src/components/layout/button/Button.tsx
+++ b/src/components/layout/button/Button.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { cn } from "../../../utils/constants";
+import { cn } from "@/utils/constants";
 
 interface ButtonProps {
 	backgroundColor?: string;

--- a/src/components/layout/footer/AuthFooter.tsx
+++ b/src/components/layout/footer/AuthFooter.tsx
@@ -1,8 +1,8 @@
-import { AuthImages } from '../../../assets';
+import { AuthImages } from '@/assets';
 import { VscGithubAlt } from 'react-icons/vsc';
 import { CiTwitter } from 'react-icons/ci';
 import { FiLinkedin, FiYoutube } from 'react-icons/fi';
-import { LanguageSwitcher } from '../..';
+import { LanguageSwitcher } from '@/components';
 
 
 const AuthFooter = () => {

--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -1,8 +1,8 @@
-import { HomeImages } from '../../../assets';
+import { HomeImages } from '@/assets';
 import { VscGithubAlt } from 'react-icons/vsc';
 import { CiTwitter } from 'react-icons/ci';
 import { FiLinkedin, FiYoutube } from 'react-icons/fi';
-import { LanguageSwitcher } from '../..';
+import { LanguageSwitcher } from '@/components';
 import { useLocation } from 'react-router-dom';
 
 

--- a/src/components/layout/navbar/AuthNavbar.tsx
+++ b/src/components/layout/navbar/AuthNavbar.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { AuthImages } from '../../../assets'
+import { AuthImages } from '@/assets'
 
 const AuthNavbar = () => {
   return (

--- a/src/components/layout/navbar/Navbar.tsx
+++ b/src/components/layout/navbar/Navbar.tsx
@@ -1,10 +1,10 @@
 import { HiMenuAlt3 } from 'react-icons/hi';
 import { AiOutlineClose } from 'react-icons/ai';
-import { HomeImages } from '../../../assets';
-import { ToggleSwitch } from '../../../components';
+import { HomeImages } from '@/assets';
+import { ToggleSwitch } from '@/components';
 import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { navLinks } from '../../../utils/constants';
+import { navLinks } from '@/utils/constants';
 import { Button } from '../button';
 import { VscAccount } from "react-icons/vsc";
 

--- a/src/components/pages/About-Page-Components/AboutHeader.tsx
+++ b/src/components/pages/About-Page-Components/AboutHeader.tsx
@@ -1,4 +1,4 @@
-import { AboutImages } from '../../../assets';
+import { AboutImages } from '@/assets';
 
 const AboutHeader = () => {
   return (

--- a/src/components/pages/About-Page-Components/JoinUsNow.tsx
+++ b/src/components/pages/About-Page-Components/JoinUsNow.tsx
@@ -1,4 +1,4 @@
-import { Button } from '../../layout';
+import { Button } from '@/components/layout';
 
 
 const JoinUsNow = () => {

--- a/src/components/pages/About-Page-Components/Mission&Vission.tsx
+++ b/src/components/pages/About-Page-Components/Mission&Vission.tsx
@@ -1,4 +1,4 @@
-import { AboutImages } from '../../../assets';
+import { AboutImages } from '@/assets';
 
 
 const MissionVission = () => {

--- a/src/components/pages/About-Page-Components/Organisers.tsx
+++ b/src/components/pages/About-Page-Components/Organisers.tsx
@@ -1,5 +1,5 @@
 import { IoLogoLinkedin } from "react-icons/io";
-import { AboutImages } from "../../../assets";
+import { AboutImages } from "@/assets";
 import { Link } from "react-router-dom";
 import { FaGithub } from "react-icons/fa6";
 

--- a/src/components/pages/About-Page-Components/WhereITStarted.tsx
+++ b/src/components/pages/About-Page-Components/WhereITStarted.tsx
@@ -1,4 +1,4 @@
-import { AboutImages } from '../../../assets';
+import { AboutImages } from '@/assets';
 
 const WhereITStarted = () => {
   return (

--- a/src/components/pages/Auth-Page-Components/AuthQuote.tsx
+++ b/src/components/pages/Auth-Page-Components/AuthQuote.tsx
@@ -1,6 +1,6 @@
 
 import { useLocation } from 'react-router-dom'
-import { AuthImages } from '../../../assets'
+import { AuthImages } from '@/assets'
 
 const AuthQuote = () => {
     const { pathname } = useLocation()

--- a/src/components/pages/Auth-Page-Components/Slider.tsx
+++ b/src/components/pages/Auth-Page-Components/Slider.tsx
@@ -1,6 +1,6 @@
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Pagination } from 'swiper/modules';
-// import { AuthImages } from '../../../assets';
+// import { AuthImages } from '@/assets';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';

--- a/src/components/pages/Home-Page-Components/BecomeMember.tsx
+++ b/src/components/pages/Home-Page-Components/BecomeMember.tsx
@@ -1,5 +1,5 @@
-import { HomeImages } from '../../../assets';
-import { Button } from '../../layout';
+import { HomeImages } from '@/assets';
+import { Button } from '@/components/layout';
 
 const BecomeMember = () => {
   const { blueDjango, blueMap } = HomeImages;

--- a/src/components/pages/Home-Page-Components/Collaboration.tsx
+++ b/src/components/pages/Home-Page-Components/Collaboration.tsx
@@ -1,6 +1,6 @@
 import { GoArrowUpRight } from 'react-icons/go';
-import { HomeImages } from '../../../assets';
-import { Button } from '../../layout';
+import { HomeImages } from '@/assets';
+import { Button } from '@/components/layout';
 
 
 const Collaboration = () => {

--- a/src/components/pages/Home-Page-Components/EventsSection.tsx
+++ b/src/components/pages/Home-Page-Components/EventsSection.tsx
@@ -1,4 +1,4 @@
-import { EventCard } from '../..';
+import { EventCard } from '@/components';
 import { Link } from 'react-router-dom';
 import { GoArrowUpRight } from 'react-icons/go';
 

--- a/src/components/pages/Home-Page-Components/Header.tsx
+++ b/src/components/pages/Home-Page-Components/Header.tsx
@@ -1,5 +1,5 @@
-import { Button } from "../../layout";
-import { HomeImages } from "../../../assets";
+import { Button } from "@/components/layout";
+import { HomeImages } from "@/assets";
 
 const Header = () => {
 	const FACTS = [

--- a/src/components/pages/Home-Page-Components/Newsletter.tsx
+++ b/src/components/pages/Home-Page-Components/Newsletter.tsx
@@ -1,6 +1,6 @@
-import { Badge, Button } from '../../layout'
+import { Badge, Button } from '@/components/layout'
 import { AiOutlineSend } from 'react-icons/ai';
-import { HomeImages } from '../../../assets';
+import { HomeImages } from '@/assets';
 
 
 const Newsletter = () => {

--- a/src/components/pages/Home-Page-Components/ProjectsSection.tsx
+++ b/src/components/pages/Home-Page-Components/ProjectsSection.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { ProjectCard } from "../..";
+import { ProjectCard } from "@/components";
 import { GoArrowUpRight } from "react-icons/go";
 import { LuArrowLeft, LuArrowRight } from "react-icons/lu";
 import { useRef } from "react";

--- a/src/components/pages/Home-Page-Components/YoutubeSection.tsx
+++ b/src/components/pages/Home-Page-Components/YoutubeSection.tsx
@@ -1,6 +1,6 @@
-import { AvatarUsers } from "../..";
-import { HomeImages } from "../../../assets";
-import { Badge, Button } from "../../layout";
+import { AvatarUsers } from "@/components";
+import { HomeImages } from "@/assets";
+import { Badge, Button } from "@/components/layout";
 import { Link } from "react-router-dom";
 import { GoArrowUpRight } from "react-icons/go";
 

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -4,7 +4,7 @@ import {
   MissionVission,
   Organisers,
   WhereITStarted,
-} from '../components/pages/About-Page-Components';
+} from '@/components/pages/About-Page-Components';
 
 const About = () => {
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import {
 	YoutubeSection,
 	Header,
 	Newsletter,
-} from "../components/pages/Home-Page-Components";
+} from "@/components/pages/Home-Page-Components";
 
 const Home = () => {
 	return (

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,7 +1,7 @@
 
 import { Outlet } from 'react-router-dom';
-import { TogglePage } from '../../components/pages/Auth-Page-Components';
-import { AuthFooter, AuthNavbar } from '../../components/layout';
+import { TogglePage } from '@/components/pages/Auth-Page-Components';
+import { AuthFooter, AuthNavbar } from '@/components/layout';
 
 const Auth = () => {
   return (

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,18 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { ILoginForm } from "../../models";
+import { ILoginForm } from "@/models";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
-import { Button } from "../../components/layout";
+import { Button } from "@/components/layout";
 import { Link } from "react-router-dom";
 import { useState } from "react";
 import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai";
-// import {Carousel} from "../../components";
+// import {Carousel} from "@/components";
 import { useNavigate } from "react-router-dom";
 import { GoArrowUpRight } from "react-icons/go";
-import AuthQuote from "../../components/pages/Auth-Page-Components/AuthQuote";
-import { signinUser } from "../../apis";
+import AuthQuote from "@/components/pages/Auth-Page-Components/AuthQuote";
+import { signinUser } from "@/apis";
 
 const Login = () => {
 	const navigate = useNavigate();

--- a/src/pages/auth/Register.tsx
+++ b/src/pages/auth/Register.tsx
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { IRegisterForm } from "../../models";
+import { IRegisterForm } from "@/models";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
-import { Button } from "../../components/layout";
+import { Button } from "@/components/layout";
 import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai";
 import { useState } from "react";
-// import {Carousel} from "../../components";
+// import {Carousel} from "@/components";
 import { useNavigate } from "react-router-dom";
-import AuthQuote from "../../components/pages/Auth-Page-Components/AuthQuote";
-import { registerUser } from "../../apis";
+import AuthQuote from "@/components/pages/Auth-Page-Components/AuthQuote";
+import { registerUser } from "@/apis";
 
 const Register = () => {
 	const navigate = useNavigate();

--- a/src/pages/auth/forgot-password/Reset-password.tsx
+++ b/src/pages/auth/forgot-password/Reset-password.tsx
@@ -1,8 +1,8 @@
 import {Link, useNavigate} from 'react-router-dom';
-import { AuthImages, HomeImages } from '../../../assets';
-import { Button } from '../../../components/layout';
+import { AuthImages, HomeImages } from '@/assets';
+import { Button } from '@/components/layout';
 import { useForm } from 'react-hook-form';
-import { ResetPasswordForm } from '../../../models';
+import { ResetPasswordForm } from '@/models';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,13 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+    },
+
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import path from "path"
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
 })


### PR DESCRIPTION
## Summary

This commit sets up aliasing paths in TypeScript to enhance module resolution and improve code readability. All instances of `../`, `../../`, and `../../../` have been replaced with their corresponding aliases throughout the project. 

Closes #13 

## Changes

- Configured path aliases in tsconfig.json for cleaner imports.
- Replaced all relative path imports with their respective aliases across the codebase.
- Updated relevant documentation to reflect the new import structure.
